### PR TITLE
Add history and licennse

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,16 @@ In this repository, for Atlas you will find:
 * :x: The original tool (not available)
 
 This repository was constructed by [Sujith Katakam](https://github.com/sujithktkm) under the supervision of [Emerson Murphy-Hill](https://github.com/CaptainEmerson). Thanks to **Tom Deering**, **Suresh Kothari**, **Jeremias Sauceda** and **Jon Mathews** for their help in establishing this repository.
+
+
+Additional information about the tool
+-------------------------------------
+
+Repository history:
+
+Atlas is now a commercial tool, and it does not exist in opensource platforms. So this repository does not maintain the original program history.
+
+License:
+
+Atlas is now a commercial tool, it is not uder opensource licese.But users or organizations can get Free license from website.
+[Free License for Atlas Lite](http://www.ensoftcorp.com/atlas/lite/) , [Academic License](http://www.ensoftcorp.com/atlas/academic-license/)


### PR DESCRIPTION
This pull request added two things at a time.

I added the explanation for repository history, and the License information about Atlas.
